### PR TITLE
Fix printer list endpoint serialization

### DIFF
--- a/main.py
+++ b/main.py
@@ -122,7 +122,8 @@ app.add_middleware(
 async def get_all_printers():
     async with engine.connect() as conn:
         result = await conn.execute(select(printers_table))
-        return result.fetchall()
+        # Convert SQLAlchemy rows to plain dictionaries so Pydantic can validate them
+        return [dict(row) for row in result.mappings().all()]
 
 @app.post("/api/printers", response_model=Printer, status_code=status.HTTP_201_CREATED, tags=["Printers"])
 async def create_printer(printer: PrinterCreate):


### PR DESCRIPTION
## Summary
- Ensure `/api/printers` returns plain dictionaries so FastAPI can serialize printer data

## Testing
- `python -m py_compile main.py`
- `python - <<'PY'
import asyncio
from main import create_tables, get_all_printers, Printer

async def test():
    await create_tables()
    res = await get_all_printers()
    print(res)
    p = [Printer.model_validate(r) for r in res]
    print(p)

asyncio.run(test())
PY`


------
https://chatgpt.com/codex/tasks/task_e_689524d5555483268f54a593d1fdeac7